### PR TITLE
Add a variable to disable the default shortcuts

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,11 @@ Normal Mode:
     +                  ... change font size bigger
     -                  ... change font size smaller
 
+If you set the variable 'g:do_not_use_default_shortcuts_for_zoom' the above shortcuts will be disable.
+To disable the default shortcut add this in your vimrc:
+
+"let g:do_not_use_default_shortcuts_for_zoom = 1"
+
 Command-line Mode:
     :ZoomIn            ... change font size bigger
     :ZoomOut           ... change font size smaller

--- a/README
+++ b/README
@@ -11,10 +11,11 @@ Normal Mode:
     +                  ... change font size bigger
     -                  ... change font size smaller
 
-If you set the variable 'g:do_not_use_default_shortcuts_for_zoom' the above shortcuts will be disable.
+If you set the variable 'g:use_default_shortcuts_for_zoom' to 0 the above 
+shortcuts will be disable. 
 To disable the default shortcut add this in your vimrc:
 
-"let g:do_not_use_default_shortcuts_for_zoom = 1"
+"let g:use_default_shortcuts_for_zoom = 0"
 
 Command-line Mode:
     :ZoomIn            ... change font size bigger

--- a/plugin/zoom.vim
+++ b/plugin/zoom.vim
@@ -15,8 +15,10 @@ command! -narg=0 ZoomOut   :call s:ZoomOut()
 command! -narg=0 ZoomReset :call s:ZoomReset()
 
 " map
-nmap + :ZoomIn<CR>
-nmap - :ZoomOut<CR>
+if !exists('g:do_not_use_default_shortcuts_for_zoom')
+  nmap + :ZoomIn<CR>
+  nmap - :ZoomOut<CR>
+endif
 
 " guifont size + 1
 function! s:ZoomIn()

--- a/plugin/zoom.vim
+++ b/plugin/zoom.vim
@@ -15,7 +15,7 @@ command! -narg=0 ZoomOut   :call s:ZoomOut()
 command! -narg=0 ZoomReset :call s:ZoomReset()
 
 " map
-if !exists('g:do_not_use_default_shortcuts_for_zoom')
+if g:use_default_shortcuts_for_zoom
   nmap + :ZoomIn<CR>
   nmap - :ZoomOut<CR>
 endif

--- a/plugin/zoom.vim
+++ b/plugin/zoom.vim
@@ -66,6 +66,11 @@ Normal Mode:
     +                  ... change font size bigger
     -                  ... change font size smaller
 
+If you set the variable 'g:do_not_use_default_shortcuts_for_zoom' the above shortcuts will be disable.
+To disable the default shortcut add this in your vimrc:
+
+"let g:do_not_use_default_shortcuts_for_zoom = 1"
+
 Command-line Mode:
     :ZoomIn            ... change font size bigger
     :ZoomOut           ... change font size smaller

--- a/plugin/zoom.vim
+++ b/plugin/zoom.vim
@@ -66,10 +66,11 @@ Normal Mode:
     +                  ... change font size bigger
     -                  ... change font size smaller
 
-If you set the variable 'g:do_not_use_default_shortcuts_for_zoom' the above shortcuts will be disable.
+If you set the variable 'g:use_default_shortcuts_for_zoom' to 0 the above 
+shortcuts will be disable. 
 To disable the default shortcut add this in your vimrc:
 
-"let g:do_not_use_default_shortcuts_for_zoom = 1"
+"let g:use_default_shortcuts_for_zoom = 0"
 
 Command-line Mode:
     :ZoomIn            ... change font size bigger


### PR DESCRIPTION
The default shortcuts "+" and "-" mess with the original behavior of the keys in Vim.

With the newly added variable "g:do_not_use_default_shortcuts_for_zoom", you can disable the mapping that the Zoom plugin does that overwrites the keys "+" and "-".
